### PR TITLE
⛔ BLOCKER before publishing release — redact PayPal credentials from logs (do not ship without this)

### DIFF
--- a/includes/class-usb-swiper-paypal-request.php
+++ b/includes/class-usb-swiper-paypal-request.php
@@ -261,6 +261,65 @@ class Usb_Swiper_Paypal_request{
 	}
 
     /**
+     * Redact sensitive request and response values before writing logs.
+     *
+     * @since 4.1.7
+     *
+     * @param mixed $data Request or response data.
+     * @return mixed
+     */
+	private function redact_sensitive_log_data( $data ) {
+
+		$sensitive_keys = array(
+			'access_token',
+			'authorization',
+			'client_secret',
+			'client_token',
+			'id_token',
+			'refresh_token',
+		);
+
+		if ( is_array( $data ) ) {
+			foreach ( $data as $key => $value ) {
+				if ( in_array( strtolower( (string) $key ), $sensitive_keys, true ) ) {
+					$data[ $key ] = '[REDACTED]';
+				} else {
+					$data[ $key ] = $this->redact_sensitive_log_data( $value );
+				}
+			}
+		}
+
+		return $data;
+	}
+
+    /**
+     * Prepare the request body for logging.
+     *
+     * @since 4.1.7
+     *
+     * @param array $request Request arguments.
+     * @return mixed|string
+     */
+	private function get_request_body_for_log( $request ) {
+
+		if ( ! is_array( $request ) || ! array_key_exists( 'body', $request ) || '' === $request['body'] || null === $request['body'] ) {
+			return '[empty]';
+		}
+
+		$body = $request['body'];
+
+		if ( is_string( $body ) ) {
+			$decoded_body = json_decode( $body, true );
+
+			if ( JSON_ERROR_NONE === json_last_error() ) {
+				$body = $decoded_body;
+			}
+		}
+
+		return $this->redact_sensitive_log_data( $body );
+	}
+
+    /**
      * Parse the api response and add log.
      *
      * @since 1.0.0
@@ -300,20 +359,16 @@ class Usb_Swiper_Paypal_request{
 				$this->api_log->log(PHP_EOL . "==========" . PHP_EOL . "==========" . PHP_EOL . "Action: ".ucwords(str_replace('_', ' ', $action_name)), $log_file);
 				$this->api_log->log('Request URL: '.$url, $log_file);
 				if ( !empty( $request['headers'] ) && is_array( $request['headers'] ) ) {
-					$this->api_log->log( 'Request Headers: ' . print_r( $request['headers'], true ), $log_file );
+					$this->api_log->log( 'Request Headers: ' . print_r( $this->redact_sensitive_log_data( $request['headers'] ), true ), $log_file );
 				}
 
-				if ( !empty($request['body']) && is_array($request['body']) ) {
-					$this->api_log->log( 'Request Body: ' . print_r( $request, true ), $log_file );
-				} elseif ( !empty($request['body']) && is_string($request['body']) ) {
-					$this->api_log->log( 'Request Body: ' . print_r(json_decode($request['body'], true), true), $log_file);
-				}
+				$this->api_log->log( 'Request Body: ' . print_r( $this->get_request_body_for_log( $request ), true ), $log_file );
 
 				$this->api_log->log('Response headers: '.print_r($headers, true), $log_file);
 				$this->api_log->log('Response Code: '.$status_code, $log_file);
 				$this->api_log->log('Response Message: '.wp_remote_retrieve_response_message($paypal_api_response), $log_file);
 				if ( !empty( $response['body']) && is_array($response['body'])) {
-					$this->api_log->log('Response Body: ' . print_r($response['body'], true), $log_file);
+					$this->api_log->log('Response Body: ' . print_r($this->redact_sensitive_log_data($response['body']), true), $log_file);
 				} elseif ( !empty($response) && is_array($response)) {
                     $response_code = ( isset($response['purchase_units'][0]['payments']['captures'][0]['processor_response']['response_code']) && !empty($response['purchase_units'][0]['payments']['captures'][0]['processor_response']['response_code'])) ? $response['purchase_units'][0]['payments']['captures'][0]['processor_response']['response_code'] : '';
                     if( !empty($response_code) ){
@@ -322,9 +377,9 @@ class Usb_Swiper_Paypal_request{
                             $response['purchase_units'][0]['payments']['captures'][0]['processor_response']['response_description'] = $response_description;
                         }
                     }
-					$this->api_log->log('Response Body: ' . print_r($response, true), $log_file);
+					$this->api_log->log('Response Body: ' . print_r($this->redact_sensitive_log_data($response), true), $log_file);
 				} else {
-					$this->api_log->log('Response Body: ' . print_r(json_decode(wp_remote_retrieve_body($response), true), true), $log_file);
+					$this->api_log->log('Response Body: ' . print_r($this->redact_sensitive_log_data(json_decode($body, true)), true), $log_file);
 				}
 
 				if ( $status_code !== 200 && $status_code !== 201 ) {

--- a/includes/class-usb-swiper-paypal-request.php
+++ b/includes/class-usb-swiper-paypal-request.php
@@ -342,6 +342,16 @@ class Usb_Swiper_Paypal_request{
 						'error_code' => $paypal_api_response->get_error_code()
 					),
 				);
+				$this->api_log->log(PHP_EOL . "==========" . PHP_EOL . "==========" . PHP_EOL . "Action: ".ucwords(str_replace('_', ' ', $action_name)), $log_file);
+				$this->api_log->log('Request URL: '.$url, $log_file);
+				if ( !empty( $request['headers'] ) && is_array( $request['headers'] ) ) {
+					$this->api_log->log( 'Request Headers: ' . print_r( $this->redact_sensitive_log_data( $request['headers'] ), true ), $log_file );
+				}
+				$this->api_log->log( 'Request Body: ' . print_r( $this->get_request_body_for_log( $request ), true ), $log_file );
+				$this->api_log->log( 'WordPress HTTP Error Code: ' . $paypal_api_response->get_error_code(), $log_file );
+				$this->api_log->log( 'WordPress HTTP Error Message: ' . $paypal_api_response->get_error_message(), $log_file );
+				$this->api_log->log( 'WordPress HTTP Error Data: ' . print_r( $this->redact_sensitive_log_data( $paypal_api_response->get_error_data() ), true ), $log_file );
+				return $response;
 			} else {
 
 				$body = wp_remote_retrieve_body($paypal_api_response);

--- a/public/class-usb-swiper-public.php
+++ b/public/class-usb-swiper-public.php
@@ -237,6 +237,12 @@ if( !class_exists( 'Usb_Swiper_Public' ) ) {
 			$vt_verification_page_id = !empty( $settings['vt_verification_page'] ) ? (int)$settings['vt_verification_page'] : '';
 			$myaccount_page_id = (int)get_option( 'woocommerce_myaccount_page_id' );
             $vt_pay_by_invoice_id = !empty( $settings['vt_paybyinvoice_page'] ) ? (int)$settings['vt_paybyinvoice_page'] : '';
+            $this->maybe_log_client_token_debug_marker( 'enqueue_scripts', array(
+                'current_page_id' => get_the_ID(),
+                'virtual_terminal_page_id' => $vt_page_id,
+                'pay_by_invoice_page_id' => $vt_pay_by_invoice_id,
+                'is_user_logged_in' => is_user_logged_in() ? 'yes' : 'no',
+            ) );
             wp_enqueue_script( 'jquery-ui-datepicker' );
             wp_enqueue_style( 'jquery-ui', USBSWIPER_URL . 'assets/css/jquery-ui.css' );
 			/**
@@ -367,6 +373,35 @@ if( !class_exists( 'Usb_Swiper_Public' ) ) {
         }
 
 		/**
+		 * Log non-sensitive PayPal client-token diagnostics when requested.
+		 *
+		 * @since 4.1.7
+		 *
+		 * @param string $stage Debug stage name.
+		 * @param array  $context Additional context.
+		 */
+		private function maybe_log_client_token_debug_marker( $stage, $context = array() ) {
+
+			if ( empty( $_GET['usb_swiper_debug_client_token'] ) || ! is_user_logged_in() ) {
+				return;
+			}
+
+			$log = new Usb_Swiper_Log();
+			$upload_dir = wp_upload_dir();
+			$log_context = array_merge(
+				array(
+					'stage' => $stage,
+					'uploads_basedir' => ! empty( $upload_dir['basedir'] ) ? $upload_dir['basedir'] : '',
+					'usbswiper_log_dir_exists' => is_dir( trailingslashit( $log->basedir ) . $log->handle ) ? 'yes' : 'no',
+					'usbswiper_log_dir_writable' => is_writable( trailingslashit( $log->basedir ) . $log->handle ) ? 'yes' : 'no',
+				),
+				$context
+			);
+
+			$log->log( 'PayPal client token debug: ' . print_r( $log_context, true ), 'paypal-client-token-debug-' . date( 'Y-m-d' ) );
+		}
+
+		/**
          * Clean up paypal checkout sdk url.
          *
          * @since 1.0.0
@@ -386,6 +421,14 @@ if( !class_exists( 'Usb_Swiper_Public' ) ) {
             $invoice_session = !empty($_GET['invoice-session']) ? json_decode( base64_decode($_GET['invoice-session'])) : '';
             $invoice_id = !empty( $invoice_session->id ) ? $invoice_session->id : '';
             $invoice_status = usbswiper_get_transaction_status($invoice_id);
+
+			$this->maybe_log_client_token_debug_marker( 'script_loader_tag', array(
+				'handle' => $handle,
+				'current_page_id' => $current_page_id,
+				'virtual_terminal_page_id' => $vt_page_id,
+				'pay_by_invoice_page_id' => $paybyinvoice_page_id,
+				'invoice_status' => $invoice_status,
+			) );
 
 			if ('usb-swiper-paypal-checkout-sdk' === $handle && ( ( !empty($vt_page_id) && $vt_page_id === $current_page_id ) || ( !empty($paybyinvoice_page_id) && $paybyinvoice_page_id === $current_page_id && strtolower($invoice_status) !== 'paid') ) ) {
 

--- a/public/class-usb-swiper-public.php
+++ b/public/class-usb-swiper-public.php
@@ -422,22 +422,25 @@ if( !class_exists( 'Usb_Swiper_Public' ) ) {
             $invoice_id = !empty( $invoice_session->id ) ? $invoice_session->id : '';
             $invoice_status = usbswiper_get_transaction_status($invoice_id);
 
-			$this->maybe_log_client_token_debug_marker( 'script_loader_tag', array(
-				'handle' => $handle,
-				'current_page_id' => $current_page_id,
-				'virtual_terminal_page_id' => $vt_page_id,
-				'pay_by_invoice_page_id' => $paybyinvoice_page_id,
-				'invoice_status' => $invoice_status,
-			) );
-
 			if ('usb-swiper-paypal-checkout-sdk' === $handle && ( ( !empty($vt_page_id) && $vt_page_id === $current_page_id ) || ( !empty($paybyinvoice_page_id) && $paybyinvoice_page_id === $current_page_id && strtolower($invoice_status) !== 'paid') ) ) {
+				$this->maybe_log_client_token_debug_marker( 'paypal_sdk_tag_matched', array(
+					'handle' => $handle,
+					'current_page_id' => $current_page_id,
+					'virtual_terminal_page_id' => $vt_page_id,
+					'pay_by_invoice_page_id' => $paybyinvoice_page_id,
+					'invoice_status' => $invoice_status,
+				) );
 
 				if( !class_exists('Usb_Swiper_Paypal_request') ) {
 					include_once USBSWIPER_PATH.'/includes/class-usb-swiper-paypal-request.php';
 				}
 
 				$Paypal_request = Usb_Swiper_Paypal_request::instance();
+				$this->maybe_log_client_token_debug_marker( 'before_get_generate_token' );
 				$generate_token = $Paypal_request->get_generate_token();
+				$this->maybe_log_client_token_debug_marker( 'after_get_generate_token', array(
+					'client_token_present' => ! empty( $generate_token ) ? 'yes' : 'no',
+				) );
 
 				$client_token = "data-client-token='{$generate_token}'";
 


### PR DESCRIPTION
> ## ⛔ Merge this before publishing `release`
>
> Without it, the header-logging block already on `release` writes `client_id:client_secret` in cleartext into `wp-content/uploads/USBSwiper/USBSwiper.log` on the first PayPal API call after deploy — on every install.
>
> Nothing is exposed today: shipped builds don't log request headers. This is a pre-release guard, not a live incident.

Draft on purpose. Opened so it's visible from the branch/PR list at release time rather than only in the issue tracker. Not ready to merge as-is — see **Review notes**.

Tracking issue: #99

## What's here

Two commits by @drewangell from 2026-05-20 that were never merged. `release` is 0 behind, so this is a clean fast-forward.

### 1. `includes/class-usb-swiper-paypal-request.php` — the part you want

Adds `redact_sensitive_log_data()`:

```php
$sensitive_keys = array(
    'access_token', 'authorization', 'client_secret',
    'client_token', 'id_token', 'refresh_token',
);
```

Recursive, and applied at **every** log site — request headers on both the error and success paths, all three response-body branches, and `WP_Error` data.

Verified output from when this briefly ran in production:

```
Action: Get Access Token
Request Headers: Array
(
    [Content-Type] => application/x-www-form-urlencoded
    [Authorization] => [REDACTED]
    [PayPal-Partner-Attribution-Id] => …
)
```

### 2. `public/class-usb-swiper-public.php` — probably **not** what you want

Adds `maybe_log_client_token_debug_marker()`, a diagnostic hook fired from `enqueue_scripts()`. It's gated behind `?usb_swiper_debug_client_token` plus `is_user_logged_in()`, so it's not wide open — but it is troubleshooting scaffolding from a debugging session, unrelated to the redaction fix.

The `+81/−35` on this file is also inflated by what looks like line-ending or whitespace churn — many `-`/`+` pairs are otherwise identical lines. Worth confirming before merging so it doesn't land as noise.

## Review notes

Three ways to take this, in rough order of preference:

1. **Cherry-pick `aad4453`'s `redact_sensitive_log_data()` only.** Gets the fix, leaves the debug scaffolding and whitespace churn behind. Cleanest.
2. **Merge in full, then strip** `maybe_log_client_token_debug_marker()` in a follow-up.
3. **Merge in full and keep it**, if that debug path is genuinely wanted in a release build. Decide deliberately rather than by default.

## Why it matters

On `release`, in `includes/class-usb-swiper-paypal-request.php`:

- **Line 190**, `get_access_token()` — `'Authorization' => 'Basic '.base64_encode($this->partner_client_id.':'.$this->partner_client_secret)`
- **Lines 302–304**, `parse_response()` — `print_r( $request['headers'], true )`, unfiltered

`request()` is the single funnel for every PayPal call and passes `$args` straight into `parse_response()` as `$request`, so the token call's `Basic` header reaches that `print_r` intact. Base64 is encoding, not encryption. `Usb_Swiper_Log::log()` has no debug gate — it always writes.

The token call passes no `$log_file`, so it lands in the shared `USBSwiper.log`. On one production host that file is 83 MB with 18,647 `Get Access Token` entries, so this path runs constantly rather than rarely.

## Before merging, also consider

- **Bump the version.** Production and `release` both currently report `4.1.6` with different code. The redaction helper is annotated `@since 4.1.7`.
- **Write an `.htaccess` when the log directory is created.** `generate_log()` already calls `mkdir()`. On the one host we operate, that directory was serving a public Apache index of every log filename until it was denied manually on 2026-08-07 — other installs still have the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
